### PR TITLE
Merging First-Logic and JourDeJeu+Ouvrier

### DIFF
--- a/pkg/people/citoyen.go
+++ b/pkg/people/citoyen.go
@@ -16,15 +16,13 @@ type CitoyenLock struct {
 
 func (c *CitoyenLock) Visite() {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.nombreVisite++
-	c.mutex.Unlock()
 }
 func (c *CitoyenLock) NombreVisites() int {
-	nbVisites := 0
 	c.mutex.Lock()
-	nbVisites = c.nombreVisite
-	c.mutex.Unlock()
-	return nbVisites
+	defer c.mutex.Unlock()
+	return c.nombreVisite
 }
 
 type Citoyen struct {


### PR DESCRIPTION
En ce moment, la seule chose que First-Logic contient de plus que JDJ+O est 5 lignes dans citoyen.go que j'ai déjà ajouté dans JDJ+O. Je suggère qu'on les merge pour avoir une branche de moins dans le projet.