### PR TITLE
Fix pour les conditions de course

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -3,5 +3,5 @@ budget: 2000
 nbOuvriers: 3
 travailOuvriers: 5
 nbCitoyens: 5
-nbJours: 120
+nbJours: 15
 dayTime: 1

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	fmt.Println("Liste des batiments dans la ville")
 	fmt.Println("=================================")
-	for _, b := range batiment.BatimentsVille {
+	for _, b := range batiment.GetBatimentAll() {
 		fmt.Println(b)
 	}
 

--- a/pkg/batiment/batiment_ville_mu.go
+++ b/pkg/batiment/batiment_ville_mu.go
@@ -1,0 +1,34 @@
+package batiment
+
+import (
+	"sync"
+)
+
+type BatimentVille struct {
+	BatimentsVille      []Batiment
+	BatimentsVilleMutex sync.RWMutex
+}
+
+func (batiments *BatimentVille) Append(nouveauBatiment Batiment) {
+	batiments.BatimentsVilleMutex.Lock()
+	defer batiments.BatimentsVilleMutex.Unlock()
+	batiments.BatimentsVille = append(batiments.BatimentsVille, nouveauBatiment)
+}
+
+func (batiments *BatimentVille) Length() int {
+	batiments.BatimentsVilleMutex.RLock()
+	defer batiments.BatimentsVilleMutex.RUnlock()
+	return len(batiments.BatimentsVille)
+}
+
+func (batiments *BatimentVille) GetIndex(index int) Batiment {
+	batiments.BatimentsVilleMutex.RLock()
+	defer batiments.BatimentsVilleMutex.RUnlock()
+	return batiments.BatimentsVille[index]
+}
+
+func GetBatimentAll() []Batiment {
+	batimentsVille.BatimentsVilleMutex.RLock()
+	defer batimentsVille.BatimentsVilleMutex.RUnlock()
+	return batimentsVille.BatimentsVille
+}

--- a/pkg/batiment/projets_mu.go
+++ b/pkg/batiment/projets_mu.go
@@ -1,0 +1,46 @@
+package batiment
+
+import (
+	"sync"
+)
+
+type ProjetVille struct {
+	ProjetsVille      []Projet
+	ProjetsVilleMutex sync.RWMutex
+}
+
+func (projets *ProjetVille) Append(nouveauProjet Projet) {
+	projets.ProjetsVilleMutex.Lock()
+	defer projets.ProjetsVilleMutex.Unlock()
+	projets.ProjetsVille = append(projets.ProjetsVille, nouveauProjet)
+}
+
+func (projets *ProjetVille) Delete(index int) {
+	projets.ProjetsVilleMutex.Lock()
+	defer projets.ProjetsVilleMutex.Unlock()
+	projets.ProjetsVille = append(projets.ProjetsVille[:index], projets.ProjetsVille[index+1:]...)
+}
+
+func (projets *ProjetVille) Length() int {
+	projets.ProjetsVilleMutex.RLock()
+	defer projets.ProjetsVilleMutex.RUnlock()
+	return len(projets.ProjetsVille)
+}
+
+func (projets *ProjetVille) Get(index int) Projet {
+	projets.ProjetsVilleMutex.RLock()
+	defer projets.ProjetsVilleMutex.RUnlock()
+	return projets.ProjetsVille[index]
+}
+
+func (projets *ProjetVille) Set(index int, val Projet) {
+	projets.ProjetsVilleMutex.Lock()
+	defer projets.ProjetsVilleMutex.Unlock()
+	projets.ProjetsVille[index] = val
+}
+
+func (projets *ProjetVille) GetAll() []Projet {
+	projets.ProjetsVilleMutex.RLock()
+	defer projets.ProjetsVilleMutex.RUnlock()
+	return projets.ProjetsVille
+}

--- a/pkg/batiment/registre.go
+++ b/pkg/batiment/registre.go
@@ -12,14 +12,15 @@ import (
 var TypesBatiments []Batiment = loadBatimentsInfos("./conf/batiments/")
 
 // Batiments contenus dans la ville
-var BatimentsVille []Batiment = []Batiment{}
+var batimentsVille BatimentVille = BatimentVille{BatimentsVille: []Batiment{}}
 
 // Tous les batiments activement en construction
 var idProjet int = 0
-var Projets []Projet = []Projet{}
+
+var projets ProjetVille = ProjetVille{ProjetsVille: []Projet{}}
 
 // On keep track de l'assignation des ouvriers
-var jobBoard map[int]Projet = make(map[int]Projet)
+var jobBoard sync.Map
 
 // Channels
 var EnConstruction = make(chan Batiment)
@@ -33,7 +34,7 @@ func RegistreStep(wg *sync.WaitGroup, done <-chan interface{}) {
 		select {
 		case b := <-EnConstruction:
 			// On ajoute la demande du maire au projet en cours
-			Projets = append(Projets, Projet{idProjet, b, 0})
+			projets.Append(Projet{idProjet, b, 0})
 			idProjet++
 		case t := <-JourneeTravail:
 			CheckWorkDone(t)
@@ -68,44 +69,47 @@ func GetBatimentsAbordables(budget int) []Batiment {
 }
 
 func DemandeTravail(id int) (Projet, error) {
-	if len(Projets) == 0 {
+	projetsLength := projets.Length()
+	if projetsLength == 0 {
 		return Projet{}, errors.New("Pas de projet en cours")
 	}
 
 	// On regarde si l'ouvrier est deja associe a un projet
-	proj, ok := jobBoard[id]
-
-	if ok {
-		// L'ouvrier est deja sur un projet
+	var proj Projet
+	if value, ok := jobBoard.Load(id); ok {
+		proj = value.(Projet)
 		return proj, nil
 	}
 
 	// On assigne un nouveau projet a l'employe
-	jobBoard[id] = Projets[rand.Intn(len(Projets))]
+	var newProj = projets.Get(rand.Intn(projetsLength))
+	jobBoard.Store(id, newProj)
 
 	//TODO: Il serait bien d'utilser capacite dans le batiment pour limiter le nombre d'ouvrier sur un projet
-	return jobBoard[id], nil
+	return newProj, nil
 }
 
 func CheckWorkDone(t Travail) {
 	//TODO: Maintenant qu'on a un jobBoard, on devrait plutot acceder au projet de cette facon
-	for idx, p := range Projets {
+	for idx, p := range projets.GetAll() {
 		if p.Id == t.Id {
 			// On ajoute le travail de l'ouvrier au projet
 			p.Travail += t.Effort
-			Projets[idx] = p
+			projets.Set(idx, p)
 
 			// Le batiment est complete, on l'enleve des projets pour le mettre dans les complets
 			if p.Travail >= p.Batiment.Work {
-				// On enleve les jobs associe au projet
-				for k, v := range jobBoard {
-					if v.Id == p.Id {
-						delete(jobBoard, k)
+				jobBoard.Range(func(k, v interface{}) bool {
+					proj, ok := v.(Projet)
+					if ok && proj.Id == p.Id {
+						jobBoard.Delete(k)
 					}
-				}
+					return true
+				})
+
 				fmt.Println("[REGISTRE]: La construction de", p.Batiment.Name, "est terminée!")
-				Projets = append(Projets[:idx], Projets[idx+1:]...)
-				BatimentsVille = append(BatimentsVille, p.Batiment)
+				projets.Delete(idx)
+				batimentsVille.Append(p.Batiment)
 			}
 
 		}
@@ -113,11 +117,12 @@ func CheckWorkDone(t Travail) {
 }
 
 func VisiteBatiment() (Batiment, error) {
-	if len(BatimentsVille) == 0 {
+	batimentsLength := batimentsVille.Length()
+	if batimentsLength == 0 {
 		return Batiment{}, errors.New("Pas de batiment dans la ville")
 	}
 	//TODO: Prendre en compte la capacite des batiments
-	batiment := BatimentsVille[rand.Intn(len(BatimentsVille))]
+	batiment := batimentsVille.GetIndex(rand.Intn(batimentsLength))
 
 	// On retourne un batiment a visiter au hasard
 	return batiment, nil


### PR DESCRIPTION
J'ai créé une branche à partir de registre-batiment pour facilement comparer le avant/après les changements. Sans les changements, le code peut parfois faire une exception "concurrent map writes" causée par une condition de course. Il y a aussi d'autres variables sujettes à une condition de course, mais ça ne cause pas d'exception, en fait ça ne change pas grand chose au résultat. Mais, c'est peut-être bon de le documenter dans le rapport, c'est de la synchronisation/exclusion mutuelle alors ça peut nous donner des points de plus.

Si vous voulez tester les conditions de course, simplement ajouter "-race" pour exécuter le code. 
- Exemple : go run -race main.go

Voici un exemple de ce que ça donne :
![image](https://user-images.githubusercontent.com/85897535/232337552-ae4d3969-f9e1-4107-a88d-76896102da16.png)

J'ai utiliser deux métodes pour régler le problème :
- sync.Map (https://pkg.go.dev/sync#Map) : un map safe thread qui utilise un mutex en arrière
- sync.RWMutex : un mutex qui permet plusieurs read en même temps ou un write (on a vu ça dans le cours IFT630)

Les batiments et les projets de la ville dans registre.go sont devenus des structures qui utilisent sync.RWMutex. Alors, si vous avez besoin vous pouvez ajouter des fonctions dans batiment_ville_mu.go et projet_mu.go
